### PR TITLE
docs: remove confusing jasmine section in migration docs

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -40,10 +40,6 @@ If you are only partially mocking a package, you might have previously used Jest
 + const { cloneDeep } = await vi.importActual('lodash/cloneDeep')
 ```
 
-**Jasmine API**
-
-Jest exports various [`jasmine`](https://jasmine.github.io/) globals (such as `jasmine.any()`). Any such instances will need to be migrated to [their Vitest counterparts](/api/).
-
 **Envs**
 
 Just like Jest, Vitest sets `NODE_ENV` to `test`, if it wasn't set before. Vitest also has a counterpart for `JEST_WORKER_ID` called `VITEST_POOL_ID` (always less than or equal to `maxThreads`), so if you rely on it, don't forget to rename it. Vitest also exposes `VITEST_WORKER_ID` which is a unique ID of a running worker - this number is not affected by `maxThreads`, and will increase with each created worker.


### PR DESCRIPTION
### Description

Hi 👋 

I found this section very confusing. This reads to me like "there is a difference between `expect.any` in Jest and you need to migrate to something on the linked to page".

But this isn't the case as far as I know. The assymetric matchers, i.e. `expect.any` `expect.anything` etc work exactly the same. There is also nothing in the Jest documentation regaring exporting anything from their forked Jasmine package.

Maybe someone can clarify what we're trying to say here? Otherwise better to just remove it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
